### PR TITLE
모달창 컴포넌트 작업 완료

### DIFF
--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -17,7 +17,7 @@ const Modal = (modalDatas, setIsOpen) => {
     createdAt,
   } = modalDatas;
 
-  const handleIsOpen = setIsOpen(false);
+  const handleIsOpen = () => setIsOpen(false);
 
   return (
     <Wrapper>

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -1,38 +1,30 @@
 import styled from 'styled-components';
 
-import SampleImage from '../assets/images/home-emoji.png';
-
-const Modal = () => {
+const Modal = ({
+  sender,
+  profileImageURL,
+  relationship,
+  content,
+  font,
+  createdAt,
+}) => {
   return (
     <Wrapper>
       <Container>
         <ModalHeader>
           <WriterArea>
-            <ProfileImage src={SampleImage} alt="profile" />
+            <ProfileImage src={profileImageURL} alt="profile" />
             <div>
               <Writer>
-                From. <span>김동훈</span>
+                From. <span>{sender}</span>
               </Writer>
-              <RelationShip>동료</RelationShip>
+              <RelationShip>{relationship}</RelationShip>
             </div>
           </WriterArea>
-          <Date>2023.07.08</Date>
+          <Date>{createdAt}</Date>
         </ModalHeader>
         <hr />
-        <ModalContents>
-          코로나가 또다시 기승을 부리는 요즘이네요. 건강, 체력 모두 조심 또
-          하세요! 코로나가 또다시 기승을 부리는 요즘이네요. 건강, 체력 모두 조심
-          또 하세요!코로나가 또다시 기승을 부리는 요즘이네요. 건강, 체력 모두
-          조심 또 하세요!코로나가 또다시 기승을 부리는 요즘이네요. 건강, 체력
-          모두 조심 또 하세요!코로나가 또다시 기승을 부리는 요즘이네요. 건강,
-          체력 모두 조심 또 하세요!코로나가 또다시 기승을 부리는 요즘이네요.
-          코로나가 또다시 기승을 부리는 요즘이네요. 건강, 체력 모두 조심 또
-          하세요! 코로나가 또다시 기승을 부리는 요즘이네요. 건강, 체력 모두 조심
-          또 하세요!코로나가 또다시 기승을 부리는 요즘이네요. 건강, 체력 모두
-          조심 또 하세요!코로나가 또다시 기승을 부리는 요즘이네요. 건강, 체력
-          모두 조심 또 하세요!코로나가 또다시 기승을 부리는 요즘이네요. 건강,
-          체력 모두 조심 또 하세요!코로나가 또다시 기승을 부리는 요즘이네요.
-        </ModalContents>
+        <ModalContents>{content}</ModalContents>
         <ModalButton>확인</ModalButton>
       </Container>
     </Wrapper>

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -7,7 +7,7 @@ const fontFamily = {
   '나눔손글씨 손편지체': 'Handletter',
 };
 
-const Modal = (modalDatas, setIsOpen) => {
+const Modal = ({ modalDatas, setIsOpen }) => {
   const {
     sender,
     profileImageURL,

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -1,13 +1,8 @@
 import styled from 'styled-components';
 
-const Modal = ({
-  sender,
-  profileImageURL,
-  relationship,
-  content,
-  font,
-  createdAt,
-}) => {
+const Modal = (modalDatas) => {
+  const { sender, profileImageURL, relationship, content, font, createdAt } =
+    modalDatas;
   return (
     <Wrapper>
       <Container>

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -15,7 +15,11 @@ const Modal = (modalDatas) => {
     content,
     font = 'Noto Sans',
     createdAt,
+    setIsOpen,
   } = modalDatas;
+
+  const handleIsOpen = setIsOpen(false);
+
   return (
     <Wrapper>
       <Container>
@@ -33,7 +37,7 @@ const Modal = (modalDatas) => {
         </ModalHeader>
         <hr />
         <ModalContents font={fontFamily[font]}>{content}</ModalContents>
-        <ModalButton>확인</ModalButton>
+        <ModalButton onClick={handleIsOpen}>확인</ModalButton>
       </Container>
     </Wrapper>
   );

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -1,8 +1,21 @@
 import styled from 'styled-components';
 
+const fontFamily = {
+  'Noto Sans': 'Noto Sans KR',
+  Pretendard: 'Pretendard',
+  나눔명조: 'Nanum Myeongjo',
+  '나눔손글씨 손편지체': 'Handletter',
+};
+
 const Modal = (modalDatas) => {
-  const { sender, profileImageURL, relationship, content, font, createdAt } =
-    modalDatas;
+  const {
+    sender,
+    profileImageURL,
+    relationship,
+    content,
+    font = 'Noto Sans',
+    createdAt,
+  } = modalDatas;
   return (
     <Wrapper>
       <Container>
@@ -19,7 +32,7 @@ const Modal = (modalDatas) => {
           <Date>{createdAt}</Date>
         </ModalHeader>
         <hr />
-        <ModalContents>{content}</ModalContents>
+        <ModalContents font={fontFamily[font]}>{content}</ModalContents>
         <ModalButton>확인</ModalButton>
       </Container>
     </Wrapper>
@@ -115,6 +128,7 @@ const ModalContents = styled.div`
   letter-spacing: -0.18px;
   overflow-y: auto;
   scrollbar-width: 4px;
+  font-family: ${(font) => `${font}, sans-serif`};
 
   &::-webkit-scrollbar {
     width: 20px;

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -7,7 +7,7 @@ const fontFamily = {
   '나눔손글씨 손편지체': 'Handletter',
 };
 
-const Modal = (modalDatas) => {
+const Modal = (modalDatas, setIsOpen) => {
   const {
     sender,
     profileImageURL,
@@ -15,7 +15,6 @@ const Modal = (modalDatas) => {
     content,
     font = 'Noto Sans',
     createdAt,
-    setIsOpen,
   } = modalDatas;
 
   const handleIsOpen = setIsOpen(false);


### PR DESCRIPTION
## 작업사항

### 메세지 상세보기 용 모달창 컴포넌트 추가

- 반응형 UI 개발
- 모달 데이터를 외부 prop으로 받도록 작업
- 모달 본문 폰트가 prop에 따라 바뀌도록 동적 스타일 정의
- 확인버튼에 이벤트핸들러 등록 (모달창 닫는 setter함수 적용할 수 있도록 함)

## Prop 정보

### modalDatas

- sender
- profileImageURL
- relationship
- content
- font (기본값: noto sans)
- createdAt

상세보기 할 메세지의 데이터들입니다

### setIsOpen

- setIsOpen

모달창 open 상태 변경 함수입니다

## 사용 예시

```
import Modal from '../components/Modal';

const mockData = {
  sender: '김동훈',
  profileImageURL: ImgUrl,
  relationship: '동료',
  content:
    '코로나가 또다시 기승을 부리는 요즘이네요. 건강, 체력 모두 조심 또 하세요!',
  font: 'Noto Sans',
  createdAt: '2023.07.08',
};

const HomePage = () => {
  const [isOpen, setIsOpen] = useState(false);

  return (
    <>
      {isOpen && <Modal modalDatas={mockData} setIsOpen={setIsOpen} />}
      ...
    </>
   );
}
```

모달창이 열고닫히는걸 메세지리스트 페이지에서 조건부 렌더링으로 처리해야할 것 같아서,
MessageListPage에서 useState로 [isOpen, setIsOpen] 을 만들고 모달창에 setIsOpen만 넘겨주면
확인버튼 눌렀을때 isOpen이 false가 되도록 처리했습니다!

## 비고

프롭 개수가 7개나 돼서
데이터에 해당하는 프롭들은 다 객체로 묶어서 받고, 컴포넌트 안에서 디스트럭쳐링으로 사용했는데
괜찮은 방법인지 모르겠군요🥲